### PR TITLE
feat(vimeo): add oembed approach to fetch poster images

### DIFF
--- a/lib/embetty.js
+++ b/lib/embetty.js
@@ -7,6 +7,7 @@ const Redis = require('../lib/cache/redis')
 const Tweet = require('./tweet')
 const VimeoVideo = require('./vimeo-video')
 const YoutubeVideo = require('./youtube-video')
+const VimeoOembedVideo = require('./vimeo-oembed-video')
 
 module.exports = class Embetty {
   constructor(cache) {
@@ -34,7 +35,8 @@ module.exports = class Embetty {
     const response = await this.get(url, options)
     return {
       data: response.body,
-      type: contentType.parse(response).type,
+      type: 'image/jpeg'
+      // type: contentType.parse(response).type,
     }
   }
 
@@ -55,6 +57,10 @@ module.exports = class Embetty {
 
   loadVimeoVideo(id, options) {
     return this.loadEmbed(Embetty.VimeoVideo, id, options)
+  }
+
+  loadVimeoOembedVideo(id, options) {
+    return this.loadEmbed(Embetty.VimeoOembedVideo, id, options)
   }
 
   loadFacebookVideo(id, options) {
@@ -89,6 +95,10 @@ module.exports = class Embetty {
 
   static get VimeoVideo() {
     return VimeoVideo
+  }
+
+  static get VimeoOembedVideo() {
+    return VimeoOembedVideo
   }
 
   static get FacebookVideo() {

--- a/lib/vimeo-oembed-video.js
+++ b/lib/vimeo-oembed-video.js
@@ -1,0 +1,42 @@
+const Video = require('./video')
+
+module.exports = class VimeoOembedVideo extends Video {
+  constructor(id, options) {
+    super(id, options)
+
+    this.h = options.h
+    this.width = options.width
+    this.height = options.height
+    this.requestTimeout = 20000
+  }
+
+  get _requestOptions() {
+    let uri = `https://vimeo.com/api/oembed.json?url=https%3A//vimeo.com/${this.id}/${this.h}`
+    if (this.width && this.height) uri = `${uri}&width=${this.width}&height=${this.height}`
+    return {
+      uri,
+      json: true,
+    }
+  }
+
+  get type() {
+    return 'vimeo'
+  }
+
+  get posterImageUrlWithoutImageSize() {
+    return this.data.thumbnail_url.replace(/[^-d_]*$ */g, '')
+  }
+
+  get getPosterImageWithNewImageSize() {
+    const posterImageWithoutImageSize = this.posterImageUrlWithoutImageSize
+    return `${posterImageWithoutImageSize}${this.width}x${this.height}`
+  }
+
+  get posterImageUrl() {
+    if (this.width && this.height) {
+      return this.getPosterImageWithNewImageSize
+    } else {
+      return this.data.thumbnail_url
+    }
+  }
+}


### PR DESCRIPTION
### Summary

Add Vimeo oembed approach to fetch poster images

### Motivation

Embetty-base not supports fetching private poster images

### Review

Use embetty-server oembed endpoint to fetch

### References